### PR TITLE
Renders settings component on top of allotment

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -39,6 +39,7 @@ body {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   width: 300px;
+  z-index: 1000;
 }
 
 .settings-dialog h2 {


### PR DESCRIPTION
Fixed issue where allotment was rendering over and through the settings component. 
![image](https://github.com/Nick-NCSU/bf/assets/40801946/17f12ee4-b58f-4351-9a02-277c1a50e9a5)
